### PR TITLE
Deprecate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# @mapbox/fontmachine
+# DEPRECATED @mapbox/fontmachine
 
 [![Build Status](https://travis-ci.org/mapbox/fontmachine.svg?branch=master)](https://travis-ci.org/mapbox/fontmachine) [![codecov](https://codecov.io/gh/mapbox/fontmachine/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/fontmachine)
+
+:warning: This code is deprecated, which means it is no longer maintained and will not receive updates. Instead of this library, we recommend using node-[fontnik directly](https://github.com/mapbox/node-fontnik).
 
 Make GL-ready pbfs and metadata for usage in fontstack API.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/mapbox/fontmachine.svg?branch=master)](https://travis-ci.org/mapbox/fontmachine) [![codecov](https://codecov.io/gh/mapbox/fontmachine/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/fontmachine)
 
-:warning: This code is deprecated, which means it is no longer maintained and will not receive updates. Instead of this library, we recommend using node-[fontnik directly](https://github.com/mapbox/node-fontnik).
+:warning: This code is deprecated, which means it is no longer maintained and will not receive updates. Instead of this library, we recommend using [node-fontnik](https://github.com/mapbox/node-fontnik) directly.
 
 Make GL-ready pbfs and metadata for usage in fontstack API.
 
@@ -43,5 +43,4 @@ $ npm install @mapbox/fontmachine
 ```sh
 $ npm test
 ```
-
 


### PR DESCRIPTION
This module is not seeing frequent updates or attention. At Mapbox we have alternative code that we use to interface with node-fontnik. So, to make it clear that this code will not be seeing future maintenance or support, I'm deprecating today.

This PR adds a deprecation note to the readme. After this merges I will also:

 - [x] Deprecate the module on npm
 - [x] Archive the repo so it is read-only

/cc @mapbox/map-design-api @mapbox/static-apis 
